### PR TITLE
fix: Profile URL format BUG

### DIFF
--- a/user.go
+++ b/user.go
@@ -267,7 +267,7 @@ func user(w http.ResponseWriter, r *http.Request) {
 	//またはカスタムurl→ResolveVanityURL→id
 
 	segs := strings.Split(r.FormValue("userid"), "/")
-	val := segs[len(segs)-2]
+	val := segs[4]
 	id := getSteamID(apiKey, val)
 
 	playerSummaries := getPlayerSummaries(apiKey, id)


### PR DESCRIPTION
steamID or customURLの値を取得するために、URLのセグメント[4]を取得することで両方に対応した